### PR TITLE
feat(sdk): add Go SDK support and update dependencies

### DIFF
--- a/sdk/fern/fern.config.json
+++ b/sdk/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "sandbox",
-  "version": "0.66.19"
+  "version": "0.81.0"
 }

--- a/sdk/fern/generators.yml
+++ b/sdk/fern/generators.yml
@@ -19,3 +19,12 @@ groups:
         output:
           location: local-file-system
           path: ../python/agent_sandbox
+  sdk-go:
+    generators:
+      - name: fernapi/fern-go-sdk
+        version: 1.12.4
+        output:
+          location: local-file-system
+          path: ./sdk-go
+        config:
+          module: github.com/agent-infra/sandbox-sdk-go

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -1,0 +1,3 @@
+# Go SDK
+
+Please refer to [https://github.com/agent-infra/sandbox-go-sdk](https://github.com/agent-infra/sandbox-go-sdk).


### PR DESCRIPTION
Added Go SDK generator configuration in fern/generators.yml with fern-go-sdk version 1.12.4. Updated the Fern version from 0.66.19 to 0.81.0 to support the new SDK. Created a basic README.md for the Go SDK directory. These changes enable Go SDK generation for the sandbox project.