### PR TITLE
fix(doc): Fixed missing required fields in the K8S Deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,13 @@ metadata:
   name: aio-sandbox
 spec:
   replicas: 2
+  selector:
+    matchLabels:
+      app: aio-sandbox
   template:
+    metadata:
+      labels:
+        app: aio-sandbox
     spec:
       containers:
       - name: aio-sandbox


### PR DESCRIPTION
Fixed missing required fields in the Kubernetes Deployment example in README.md.


before
```shell
The Deployment "aio-sandbox" is invalid: 
* spec.selector: Required value
* spec.template.metadata.labels: Invalid value: null: `selector` does not match template `labels`
```