### PR TITLE
fix: replace 3 bare except clauses with except Exception

### DIFF
--- a/evaluation/main.py
+++ b/evaluation/main.py
@@ -84,14 +84,14 @@ async def cleanup_global_mcp_session():
     if _mcp_session:
         try:
             await _mcp_session.__aexit__(None, None, None)
-        except:
+        except Exception:
             pass
         _mcp_session = None
 
     if _mcp_streams:
         try:
             await _mcp_streams.__aexit__(None, None, None)
-        except:
+        except Exception:
             pass
         _mcp_streams = None
 

--- a/sdk/python/agent_sandbox/core/pydantic_utilities.py
+++ b/sdk/python/agent_sandbox/core/pydantic_utilities.py
@@ -247,7 +247,7 @@ def _get_model_fields(model: Type["Model"]) -> Mapping[str, PydanticField]:
 def _get_field_default(field: PydanticField) -> Any:
     try:
         value = field.get_default()  # type: ignore[union-attr]
-    except:
+    except Exception:
         value = field.default
     if IS_PYDANTIC_V2:
         from pydantic_core import PydanticUndefined


### PR DESCRIPTION
## What
Replace 3 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.