### PR TITLE
docs(website): fix incorrect Chinese documentation link path

### DIFF
--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -13,7 +13,7 @@ hero:
   actions:
     - theme: brand
       text: 开始使用
-      link: /zh/guide/start/introduction
+      link: /guide/start/introduction
     - theme: alt
       text: GitHub
       link: https://github.com/agent-infra/sandbox


### PR DESCRIPTION
The Chinese documentation index page had an incorrect relative path for the "Get Started" link. The path was missing the language prefix which could cause 404 errors for Chinese users. This change ensures the link properly resolves to the Chinese version of the introduction page.