### PR TITLE
docs(website): fix Chinese guide link and reorder locales

### DIFF
--- a/website/docs/zh/index.md
+++ b/website/docs/zh/index.md
@@ -13,7 +13,7 @@ hero:
   actions:
     - theme: brand
       text: 开始使用
-      link: /zh/guide/start/introduction
+      link: /guide/start/introduction
     - theme: alt
       text: GitHub
       link: https://github.com/agent-infra/sandbox

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -106,6 +106,15 @@ export default defineConfig({
     },
     locales: [
       {
+        lang: 'en',
+        label: 'English',
+        editLink: {
+          docRepoBaseUrl:
+            'https://github.com/agent-infra/sandbox/tree/main/site/docs',
+          text: '📝 Edit this page on GitHub',
+        },
+      },
+      {
         lang: 'zh',
         label: '简体中文',
         editLink: {
@@ -117,15 +126,6 @@ export default defineConfig({
           filterNameText: '过滤',
           filterPlaceholderText: '输入关键词',
           filterNoResultText: '未找到匹配的 API',
-        },
-      },
-      {
-        lang: 'en',
-        label: 'English',
-        editLink: {
-          docRepoBaseUrl:
-            'https://github.com/agent-infra/sandbox/tree/main/site/docs',
-          text: '📝 Edit this page on GitHub',
         },
       },
     ],


### PR DESCRIPTION
The Chinese guide link was incorrectly pointing to an absolute path instead of the localized path. Also reordered the locales array to put English first as it's the primary language. These changes improve the documentation navigation experience and maintain consistency in the language ordering.