### PR TITLE
Fix #130: register_skills ,restart container .  skills not found.

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       # for gh cli
       GITHUB_TOKEN: ""
       # Claude Skills
-      AIO_SKILLS_PATH: ${AIO_SKILLS_PATH:-}
+      AIO_SKILLS_PATH: ${AIO_SKILLS_PATH:-/home/gem/.claude/skills/}
       # Features
       DISABLE_JUPYTER: ${DISABLE_JUPYTER:-false}
       DISABLE_CODE_SERVER: ${DISABLE_CODE_SERVER:-false}


### PR DESCRIPTION
Closes #130

Sets the default value of `AIO_SKILLS_PATH` in `docker-compose.yaml` to `/home/gem/.claude/skills/` (line 46), matching the path used by `client.skills.register_skills()`. Previously the default was an empty string, so after a container restart the skills service had no path to scan, causing `list_metadata()` to return an empty collection despite files being present on disk.

- `docker-compose.yaml` — `AIO_SKILLS_PATH` environment variable default updated from `${AIO_SKILLS_PATH:-}` to `${AIO_SKILLS_PATH:-/home/gem/.claude/skills/}`

Verified by registering a skill zip to `/home/gem/.claude/skills/`, restarting the container, and confirming `client.skills.list_metadata()` returns the expected skill entry instead of an empty `skills=[]` list.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*