### PR TITLE
fix: resolve 6 verified bugs across SDK, evaluation, and examples

### DIFF
--- a/evaluation/agent_loop.py
+++ b/evaluation/agent_loop.py
@@ -311,8 +311,11 @@ class AzureOpenAIAgentLoop(BaseAgentLoop):
                     }
                 )
 
-        # If we hit max iterations, return what we have
-        return messages[-1].get("content", ""), tool_metrics
+        # If we hit max iterations, find the last assistant message
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant" and msg.get("content"):
+                return msg["content"], tool_metrics
+        return "", tool_metrics
 
 
 # ============================================================================
@@ -549,7 +552,11 @@ class OpenAIAgentLoop(BaseAgentLoop):
                     }
                 )
 
-        return messages[-1].get("content", ""), tool_metrics
+        # If we hit max iterations, find the last assistant message
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant" and msg.get("content"):
+                return msg["content"], tool_metrics
+        return "", tool_metrics
 
 
 # ============================================================================

--- a/evaluation/tests/test_max_iterations_fallback.py
+++ b/evaluation/tests/test_max_iterations_fallback.py
@@ -1,0 +1,129 @@
+"""
+Unit tests for the max_iterations fallback behavior in agent loops.
+
+Verifies that when max_iterations is reached, the agent returns the last
+assistant message rather than the last message (which may be a tool response).
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+# Mock external dependencies before importing agent_loop
+sys.modules.setdefault("mcp", MagicMock())
+sys.modules.setdefault("openai", MagicMock())
+
+from agent_loop import AzureOpenAIAgentLoop, OpenAIAgentLoop
+
+
+class _FakeChoice:
+    """Minimal stand-in for ``response.choices[0]``."""
+
+    def __init__(self, content, tool_calls=None):
+        self.message = MagicMock()
+        self.message.content = content
+        self.message.tool_calls = tool_calls
+
+
+class _FakeResponse:
+    def __init__(self, content, tool_calls=None):
+        self.choices = [_FakeChoice(content, tool_calls)]
+
+
+class _FakeToolCall:
+    def __init__(self, name, arguments):
+        self.id = "call_test123"
+        self.function = MagicMock()
+        self.function.name = name
+        self.function.arguments = arguments
+
+
+class TestMaxIterationsFallback(unittest.IsolatedAsyncioTestCase):
+    """When max_iterations is exhausted the loop must return the last *assistant* message."""
+
+    @patch("agent_loop.OpenAI")
+    async def test_openai_returns_last_assistant_message(self, mock_openai_cls):
+        """OpenAIAgentLoop should return the last assistant content, not a tool response."""
+        session = AsyncMock()
+
+        # Simulate: every iteration the model calls a tool (never finishes naturally)
+        tool_call = _FakeToolCall("some_tool", '{"arg": "val"}')
+        tool_response = _FakeResponse("I am working on it...", tool_calls=[tool_call])
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = tool_response
+        mock_openai_cls.return_value = mock_client
+
+        # MCP tool execution returns a dummy result
+        session.call_tool = AsyncMock(return_value={"content": [{"type": "text", "text": "tool output"}]})
+
+        loop = OpenAIAgentLoop(
+            mcp_session=session,
+            max_iterations=2,
+            api_key="test",
+        )
+
+        result_text, metrics = await loop.run(
+            "test prompt",
+            tools=[{"type": "function", "function": {"name": "some_tool", "parameters": {}}}],
+        )
+
+        # The result should be the assistant's content, not the tool response string
+        self.assertEqual(result_text, "I am working on it...")
+        # It should NOT be the stringified tool result
+        self.assertNotIn("tool output", result_text)
+
+    @patch("agent_loop.AzureOpenAI")
+    async def test_azure_returns_last_assistant_message(self, mock_azure_cls):
+        """AzureOpenAIAgentLoop should return the last assistant content, not a tool response."""
+        session = AsyncMock()
+
+        tool_call = _FakeToolCall("another_tool", '{}')
+        tool_response = _FakeResponse("Processing your request...", tool_calls=[tool_call])
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = tool_response
+        mock_azure_cls.return_value = mock_client
+
+        session.call_tool = AsyncMock(return_value={"content": [{"type": "text", "text": "result"}]})
+
+        loop = AzureOpenAIAgentLoop(
+            mcp_session=session,
+            max_iterations=2,
+            azure_endpoint="https://test.openai.azure.com",
+            azure_api_key="test",
+            azure_deployment="gpt-4",
+        )
+
+        result_text, metrics = await loop.run(
+            "test prompt",
+            tools=[{"type": "function", "function": {"name": "another_tool", "parameters": {}}}],
+        )
+
+        self.assertEqual(result_text, "Processing your request...")
+
+    @patch("agent_loop.OpenAI")
+    async def test_returns_empty_when_no_assistant_message(self, mock_openai_cls):
+        """If somehow there are no assistant messages, return empty string."""
+        session = AsyncMock()
+
+        mock_client = MagicMock()
+        mock_openai_cls.return_value = mock_client
+
+        loop = OpenAIAgentLoop(
+            mcp_session=session,
+            max_iterations=0,  # Will never enter the while loop
+            api_key="test",
+        )
+
+        result_text, metrics = await loop.run("test prompt")
+
+        # With 0 iterations, messages only has system+user, no assistant
+        self.assertEqual(result_text, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/browser-use-cua/main.py
+++ b/examples/browser-use-cua/main.py
@@ -1,16 +1,13 @@
 import asyncio
+import base64
 import os
+from io import BytesIO
 from typing import TYPE_CHECKING
 from dotenv import load_dotenv
 from browser_use import Agent, Tools
 from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.llm import ChatOpenAI
 from browser_use.agent.views import ActionResult
-
-import asyncio
-import base64
-import os
-from io import BytesIO
 
 from agent_sandbox import Sandbox
 from agent_sandbox.browser.types.action import (
@@ -277,9 +274,6 @@ async def handle_cua_action(action: "ComputerAction") -> ActionResult:
         return ActionResult(error=f"{ERROR_MSG}: {e}")
 
 
-tools = Tools()
-
-
 @tools.registry.action(
     "Use Sandbox GUI as a fallback when standard browser actions cannot achieve the desired goal. "
     "This action takes a screenshot and uses OpenAI CUA to determine the next GUI action, "
@@ -436,7 +430,4 @@ if __name__ == "__main__":
     print("  - Custom UI elements that don't respond to standard actions")
     print()
 
-    asyncio.run(main())
-
-if __name__ == "__main__":
     asyncio.run(main())

--- a/examples/site-to-markdown/main.py
+++ b/examples/site-to-markdown/main.py
@@ -30,11 +30,17 @@ async def site_to_markdown():
             await page.screenshot(full_page=False, type='png')
         ).decode('utf-8')
 
+    # Write HTML to a temp file in sandbox to avoid code injection via triple-quote breakage
+    import tempfile
+    html_b64 = base64.b64encode(html.encode("utf-8")).decode("utf-8")
+
     # Jupyter: Run code in sandbox to convert html to markdown
     c.jupyter.execute_code(
         code=f"""
+import base64
 from markdownify import markdownify
-html = '''{html}'''
+
+html = base64.b64decode("{html_b64}").decode("utf-8")
 screenshot_b64 = "{screenshot_b64}"
 
 md = f"{{markdownify(html)}}\\n\\n![Screenshot](data:image/png;base64,{{screenshot_b64}})"

--- a/sdk/js/__test__/core/createRequestUrl.test.ts
+++ b/sdk/js/__test__/core/createRequestUrl.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { createRequestUrl } from '../../src/core/fetcher/createRequestUrl.js';
+
+describe('createRequestUrl', () => {
+  it('should append query string with ? when baseUrl has no query params', () => {
+    const result = createRequestUrl('https://api.example.com/v1', { key: 'value' });
+    expect(result).toBe('https://api.example.com/v1?key=value');
+  });
+
+  it('should append query string with & when baseUrl already has query params', () => {
+    const result = createRequestUrl('https://api.example.com/v1?existing=param', { key: 'value' });
+    expect(result).toBe('https://api.example.com/v1?existing=param&key=value');
+  });
+
+  it('should return baseUrl unchanged when no query parameters provided', () => {
+    const result = createRequestUrl('https://api.example.com/v1');
+    expect(result).toBe('https://api.example.com/v1');
+  });
+
+  it('should return baseUrl unchanged when query parameters are empty', () => {
+    const result = createRequestUrl('https://api.example.com/v1', {});
+    expect(result).toBe('https://api.example.com/v1');
+  });
+
+  it('should handle baseUrl with existing ? but no additional params', () => {
+    const result = createRequestUrl('https://api.example.com/v1?existing=param');
+    expect(result).toBe('https://api.example.com/v1?existing=param');
+  });
+
+  it('should not produce double ? when baseUrl has query params', () => {
+    const result = createRequestUrl('https://api.example.com/v1?a=1', { b: '2' });
+    expect(result).not.toContain('??');
+    expect(result).toBe('https://api.example.com/v1?a=1&b=2');
+  });
+
+  it('should handle multiple query parameters', () => {
+    const result = createRequestUrl('https://api.example.com/v1', { a: '1', b: '2' });
+    expect(result).toContain('a=1');
+    expect(result).toContain('b=2');
+    expect(result.indexOf('?')).toBe(result.lastIndexOf('?'));
+  });
+});

--- a/sdk/js/__test__/providers/volcengine.test.ts
+++ b/sdk/js/__test__/providers/volcengine.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the sign module before importing VolcengineProvider
+vi.mock('../../src/providers/sign', () => ({
+  request: vi.fn(),
+}));
+
+import { VolcengineProvider } from '../../src/providers/volcengine.js';
+import { request } from '../../src/providers/sign';
+
+const mockedRequest = vi.mocked(request);
+
+describe('VolcengineProvider', () => {
+  let provider: VolcengineProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new VolcengineProvider({
+      accessKey: 'test-access-key',
+      secretKey: 'test-secret-key',
+    });
+  });
+
+  describe('createSandbox - no duplicate keys from spread (Bug #3)', () => {
+    it('should not include camelCase duplicates of PascalCase fields', async () => {
+      mockedRequest.mockResolvedValue({ Result: { SandboxId: 'sb-123' } });
+
+      await provider.createSandbox('func-123', 60, {
+        metadata: { key: 'val' },
+        cpuMilli: 1000,
+        memoryMB: 512,
+      });
+
+      expect(mockedRequest).toHaveBeenCalledTimes(1);
+      const bodyStr = mockedRequest.mock.calls[0][8] as string;
+      const body = JSON.parse(bodyStr);
+
+      // Should have PascalCase keys from explicit mapping
+      expect(body.FunctionId).toBe('func-123');
+      expect(body.CpuMilli).toBe(1000);
+      expect(body.MemoryMB).toBe(512);
+
+      // Should NOT have camelCase duplicates from spread
+      expect(body.cpuMilli).toBeUndefined();
+      expect(body.memoryMB).toBeUndefined();
+      expect(body.metadata).toBeUndefined();
+    });
+  });
+
+  describe('listSandboxes - no duplicate keys from spread (Bug #3)', () => {
+    it('should not include camelCase duplicates of PascalCase fields', async () => {
+      // First call is listSandboxes, second is getApigDomains (ListTriggers)
+      mockedRequest
+        .mockResolvedValueOnce({ Result: { Sandboxes: [], Total: 0 } })
+        .mockResolvedValueOnce({ Result: { Items: [] } });
+
+      await provider.listSandboxes('func-123', {
+        sandboxId: 'sb-456',
+        pageNumber: 2,
+        pageSize: 20,
+        status: 'running',
+      });
+
+      // First call is the actual listSandboxes request
+      const bodyStr = mockedRequest.mock.calls[0][8] as string;
+      const body = JSON.parse(bodyStr);
+
+      // Should have PascalCase keys from explicit mapping
+      expect(body.FunctionId).toBe('func-123');
+      expect(body.SandboxId).toBe('sb-456');
+      expect(body.PageNumber).toBe(2);
+      expect(body.PageSize).toBe(20);
+      expect(body.Status).toBe('running');
+
+      // Should NOT have camelCase duplicates from spread
+      expect(body.sandboxId).toBeUndefined();
+      expect(body.pageNumber).toBeUndefined();
+      expect(body.pageSize).toBeUndefined();
+      expect(body.status).toBeUndefined();
+    });
+  });
+
+  describe('error handling - rethrow instead of swallow (Bug #4)', () => {
+    it('createSandbox should throw errors instead of returning them', async () => {
+      const testError = new Error('API connection failed');
+      mockedRequest.mockRejectedValue(testError);
+
+      await expect(provider.createSandbox('func-123', 60)).rejects.toThrow('API connection failed');
+    });
+
+    it('deleteSandbox should throw errors instead of returning them', async () => {
+      const testError = new Error('Sandbox not found');
+      mockedRequest.mockRejectedValue(testError);
+
+      await expect(provider.deleteSandbox('func-123', 'sb-123')).rejects.toThrow('Sandbox not found');
+    });
+
+    it('getSandbox should throw errors instead of returning them', async () => {
+      const testError = new Error('Network error');
+      mockedRequest.mockRejectedValue(testError);
+
+      await expect(provider.getSandbox('func-123', 'sb-123')).rejects.toThrow('Network error');
+    });
+
+    it('setSandboxTimeout should throw errors instead of returning them', async () => {
+      const testError = new Error('Invalid timeout');
+      mockedRequest.mockRejectedValue(testError);
+
+      await expect(provider.setSandboxTimeout('func-123', 'sb-123', 120)).rejects.toThrow('Invalid timeout');
+    });
+
+    it('listSandboxes should throw errors instead of returning them', async () => {
+      const testError = new Error('Permission denied');
+      mockedRequest.mockRejectedValue(testError);
+
+      await expect(provider.listSandboxes('func-123')).rejects.toThrow('Permission denied');
+    });
+  });
+});

--- a/sdk/js/src/core/fetcher/createRequestUrl.ts
+++ b/sdk/js/src/core/fetcher/createRequestUrl.ts
@@ -2,5 +2,9 @@ import { toQueryString } from "../url/qs.js";
 
 export function createRequestUrl(baseUrl: string, queryParameters?: Record<string, unknown>): string {
     const queryString = toQueryString(queryParameters, { arrayFormat: "repeat" });
-    return queryString ? `${baseUrl}?${queryString}` : baseUrl;
+    if (!queryString) {
+        return baseUrl;
+    }
+    const separator = baseUrl.includes('?') ? '&' : '?';
+    return `${baseUrl}${separator}${queryString}`;
 }

--- a/sdk/js/src/providers/volcengine.ts
+++ b/sdk/js/src/providers/volcengine.ts
@@ -69,7 +69,6 @@ export class VolcengineProvider extends BaseProvider {
         MemoryMB: params.memoryMB,
         MaxConcurrency: params.maxConcurrency,
         RequestTimeout: params.requestTimeout,
-        ...kwargs[0]
       });
 
       const response = await request(
@@ -86,7 +85,7 @@ export class VolcengineProvider extends BaseProvider {
 
       return response;
     } catch (error) {
-      return error;
+      throw error;
     }
   }
 
@@ -124,7 +123,7 @@ export class VolcengineProvider extends BaseProvider {
 
       return response;
     } catch (error) {
-      return error;
+      throw error;
     }
   }
 
@@ -202,7 +201,7 @@ export class VolcengineProvider extends BaseProvider {
 
       return response;
     } catch (error) {
-      return error;
+      throw error;
     }
   }
 
@@ -241,7 +240,7 @@ export class VolcengineProvider extends BaseProvider {
 
       return response;
     } catch (error) {
-      return error;
+      throw error;
     }
   }
 
@@ -263,7 +262,6 @@ export class VolcengineProvider extends BaseProvider {
         PageSize: params.pageSize || 10,
         ImageUrl: params.imageUrl,
         Status: params.status,
-        ...kwargs[0]
       });
 
       const response = await request(
@@ -301,7 +299,7 @@ export class VolcengineProvider extends BaseProvider {
 
       return response;
     } catch (error) {
-      return error;
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #134 and 5 additional verified bugs found through source code review.

- **Bug 1** (Fixes #134): `createRequestUrl` produced double `?` when `baseUrl` already contained query parameters — now uses `&` separator when `?` is already present
- **Bug 2**: Agent loop `max_iterations` fallback returned `messages[-1]` which could be a tool response instead of an assistant message — now searches backwards for the last assistant message in both `AzureOpenAIAgentLoop` and `OpenAIAgentLoop`
- **Bug 3**: Volcengine `createSandbox`/`listSandboxes` spread `...kwargs[0]` on top of already-mapped PascalCase fields, producing duplicate camelCase+PascalCase keys in JSON body — removed redundant spread
- **Bug 4**: All Volcengine catch blocks silently swallowed errors via `return error` instead of rethrowing — changed to `throw error` so callers can handle failures properly
- **Bug 5**: `site-to-markdown` example injected raw HTML into f-string with triple quotes, allowing code injection if HTML contained `'''` — now base64-encodes HTML and decodes inside the sandbox
- **Bug 6**: `browser-use-cua` example had duplicate imports (`asyncio`, `os`), duplicate `Tools()` instantiation, and duplicate `__main__` block — cleaned up to single definitions

## Test plan

- [x] Added unit tests for `createRequestUrl` (7 tests) — all passing
- [x] Added unit tests for Volcengine `createSandbox`/`listSandboxes` duplicate key prevention (2 tests) — all passing
- [x] Added unit tests for Volcengine error rethrowing across all 5 methods (5 tests) — all passing
- [x] Added unit tests for agent loop `max_iterations` fallback behavior (3 tests)
- [x] Verified all 14 JS tests pass via `vitest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)