### PR TITLE
fix(sdk): use & separator when baseUrl already contains query params

### DIFF
--- a/sdk/js/__test__/core/createRequestUrl.test.ts
+++ b/sdk/js/__test__/core/createRequestUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { createRequestUrl } from '../../src/core/fetcher/createRequestUrl.js';
+
+describe('createRequestUrl', () => {
+  it('should return baseUrl unchanged when no query parameters', () => {
+    expect(createRequestUrl('https://api.example.com/v1')).toBe('https://api.example.com/v1');
+  });
+
+  it('should append query string with ? when baseUrl has no query params', () => {
+    const result = createRequestUrl('https://api.example.com/v1', { key: 'value' });
+    expect(result).toBe('https://api.example.com/v1?key=value');
+  });
+
+  it('should append query string with & when baseUrl already has query params', () => {
+    const result = createRequestUrl('https://api.example.com/v1?token=abc', { key: 'value' });
+    expect(result).toBe('https://api.example.com/v1?token=abc&key=value');
+  });
+
+  it('should handle empty query parameters', () => {
+    const result = createRequestUrl('https://api.example.com/v1?token=abc', {});
+    expect(result).toBe('https://api.example.com/v1?token=abc');
+  });
+});

--- a/sdk/js/src/core/fetcher/createRequestUrl.ts
+++ b/sdk/js/src/core/fetcher/createRequestUrl.ts
@@ -2,5 +2,9 @@ import { toQueryString } from "../url/qs.js";
 
 export function createRequestUrl(baseUrl: string, queryParameters?: Record<string, unknown>): string {
     const queryString = toQueryString(queryParameters, { arrayFormat: "repeat" });
-    return queryString ? `${baseUrl}?${queryString}` : baseUrl;
+    if (!queryString) {
+        return baseUrl;
+    }
+    const separator = baseUrl.includes("?") ? "&" : "?";
+    return `${baseUrl}${separator}${queryString}`;
 }


### PR DESCRIPTION
## Summary

`createRequestUrl()` always joins query parameters with `?`, producing invalid URLs when `baseUrl` already contains query parameters.

## Problem

```typescript
// baseUrl with existing query params:
createRequestUrl('https://api.example.com/v1?token=abc', { key: 'value' })
// Before: 'https://api.example.com/v1?token=abc?key=value'  ← BROKEN (double ?)
// After:  'https://api.example.com/v1?token=abc&key=value'  ← CORRECT
```

This affects any user who passes authentication tokens or other parameters in the base URL.

## Fix

Check whether `baseUrl` already contains `?` and use `&` as separator accordingly.

## Testing

Added 4 unit tests in `createRequestUrl.test.ts` covering:
- No query parameters
- baseUrl without existing params (uses `?`)
- baseUrl with existing params (uses `&`)
- Empty query parameters object

Fixes #134