### PR TITLE
fix(volcengine): remove duplicate camelCase keys in createSandbox/listSandboxes

### DIFF
--- a/sdk/js/__test__/providers/volcengine.test.ts
+++ b/sdk/js/__test__/providers/volcengine.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the sign module before importing VolcengineProvider
+vi.mock('../../src/providers/sign', () => ({
+  request: vi.fn(),
+}));
+
+import { VolcengineProvider } from '../../src/providers/volcengine.js';
+import { request } from '../../src/providers/sign';
+
+const mockedRequest = vi.mocked(request);
+
+describe('VolcengineProvider', () => {
+  let provider: VolcengineProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new VolcengineProvider({
+      accessKey: 'test-access-key',
+      secretKey: 'test-secret-key',
+    });
+  });
+
+  describe('createSandbox - no duplicate keys from spread', () => {
+    it('should not include camelCase duplicates of PascalCase fields', async () => {
+      mockedRequest.mockResolvedValue({ Result: { SandboxId: 'sb-123' } });
+
+      await provider.createSandbox('func-123', 60, {
+        metadata: { key: 'val' },
+        cpuMilli: 1000,
+        memoryMB: 512,
+      });
+
+      expect(mockedRequest).toHaveBeenCalledTimes(1);
+      const bodyStr = mockedRequest.mock.calls[0][8] as string;
+      const body = JSON.parse(bodyStr);
+
+      // Should have PascalCase keys from explicit mapping
+      expect(body.FunctionId).toBe('func-123');
+      expect(body.CpuMilli).toBe(1000);
+      expect(body.MemoryMB).toBe(512);
+
+      // Should NOT have camelCase duplicates from spread
+      expect(body.cpuMilli).toBeUndefined();
+      expect(body.memoryMB).toBeUndefined();
+      expect(body.metadata).toBeUndefined();
+    });
+  });
+
+  describe('listSandboxes - no duplicate keys from spread', () => {
+    it('should not include camelCase duplicates of PascalCase fields', async () => {
+      // First call is listSandboxes, second is getApigDomains (ListTriggers)
+      mockedRequest
+        .mockResolvedValueOnce({ Result: { Sandboxes: [], Total: 0 } })
+        .mockResolvedValueOnce({ Result: { Items: [] } });
+
+      await provider.listSandboxes('func-123', {
+        sandboxId: 'sb-456',
+        pageNumber: 2,
+        pageSize: 20,
+        status: 'running',
+      });
+
+      // First call is the actual listSandboxes request
+      const bodyStr = mockedRequest.mock.calls[0][8] as string;
+      const body = JSON.parse(bodyStr);
+
+      // Should have PascalCase keys from explicit mapping
+      expect(body.FunctionId).toBe('func-123');
+      expect(body.SandboxId).toBe('sb-456');
+      expect(body.PageNumber).toBe(2);
+      expect(body.PageSize).toBe(20);
+      expect(body.Status).toBe('running');
+
+      // Should NOT have camelCase duplicates from spread
+      expect(body.sandboxId).toBeUndefined();
+      expect(body.pageNumber).toBeUndefined();
+      expect(body.pageSize).toBeUndefined();
+      expect(body.status).toBeUndefined();
+    });
+  });
+});

--- a/sdk/js/src/providers/volcengine.ts
+++ b/sdk/js/src/providers/volcengine.ts
@@ -69,7 +69,6 @@ export class VolcengineProvider extends BaseProvider {
         MemoryMB: params.memoryMB,
         MaxConcurrency: params.maxConcurrency,
         RequestTimeout: params.requestTimeout,
-        ...kwargs[0]
       });
 
       const response = await request(
@@ -263,7 +262,6 @@ export class VolcengineProvider extends BaseProvider {
         PageSize: params.pageSize || 10,
         ImageUrl: params.imageUrl,
         Status: params.status,
-        ...kwargs[0]
       });
 
       const response = await request(


### PR DESCRIPTION
## Summary

Fixes #174.

Both `createSandbox` and `listSandboxes` in `sdk/js/src/providers/volcengine.ts` build the JSON body by first explicitly mapping `params.xxx` to PascalCase keys, then spreading `...kwargs[0]` on top — which re-adds every user-supplied camelCase key on top of its PascalCase equivalent.

This PR removes the redundant spread, so the JSON body only contains the PascalCase keys as intended.

## Test plan

- [x] Added `sdk/js/__test__/providers/volcengine.test.ts` with 2 tests covering `createSandbox` and `listSandboxes` — verifies PascalCase keys are present and camelCase keys are absent from the serialized body.

## Related

This is part of splitting closed PR #167 into focused single-bug PRs. Bugs 1 (#171) and 2 (#173) are already open individually. This PR handles Bug 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)