### PR TITLE
fix(examples): base64-encode HTML in site-to-markdown to prevent f-string injection

### DIFF
--- a/examples/site-to-markdown/main.py
+++ b/examples/site-to-markdown/main.py
@@ -30,11 +30,18 @@ async def site_to_markdown():
             await page.screenshot(full_page=False, type='png')
         ).decode('utf-8')
 
+    # Base64-encode the HTML before injecting into the f-string so that
+    # triple-quote sequences, backslashes, or closing-string markers in
+    # the page content cannot break out of the generated Python source.
+    html_b64 = base64.b64encode(html.encode("utf-8")).decode("utf-8")
+
     # Jupyter: Run code in sandbox to convert html to markdown
     c.jupyter.execute_code(
         code=f"""
+import base64
 from markdownify import markdownify
-html = '''{html}'''
+
+html = base64.b64decode("{html_b64}").decode("utf-8")
 screenshot_b64 = "{screenshot_b64}"
 
 md = f"{{markdownify(html)}}\\n\\n![Screenshot](data:image/png;base64,{{screenshot_b64}})"


### PR DESCRIPTION
## Summary

Fixes #178.

The `site-to-markdown` example interpolated scraped HTML directly into an f-string containing an inner triple-quoted literal. Pages whose content includes `'''` (or stray backslashes) break out of the string, producing either a SyntaxError or arbitrary Python execution in the sandbox.

Fix: base64-encode the HTML on the host and decode it inside the sandbox. Only ASCII alphanumerics and `+/=` cross the f-string boundary, so no page content can alter the generated Python source.

## Test plan

- [x] Read the generated Jupyter code for a page containing `'''` in the body — previously raised SyntaxError, now runs cleanly and produces correct markdown.

## Related

Part of splitting closed PR #167 into focused single-bug PRs. Previously opened: #171 (Bug 1), #173 (Bug 2), #175 (Bug 3), #177 (Bug 4). This is Bug 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)