### PR TITLE
fix(examples): deduplicate imports, Tools() instantiation, and __main__ block in browser-use-cua

### DIFF
--- a/examples/browser-use-cua/main.py
+++ b/examples/browser-use-cua/main.py
@@ -1,16 +1,13 @@
 import asyncio
+import base64
 import os
+from io import BytesIO
 from typing import TYPE_CHECKING
 from dotenv import load_dotenv
 from browser_use import Agent, Tools
 from browser_use.browser import BrowserProfile, BrowserSession
 from browser_use.llm import ChatOpenAI
 from browser_use.agent.views import ActionResult
-
-import asyncio
-import base64
-import os
-from io import BytesIO
 
 from agent_sandbox import Sandbox
 from agent_sandbox.browser.types.action import (
@@ -277,9 +274,6 @@ async def handle_cua_action(action: "ComputerAction") -> ActionResult:
         return ActionResult(error=f"{ERROR_MSG}: {e}")
 
 
-tools = Tools()
-
-
 @tools.registry.action(
     "Use Sandbox GUI as a fallback when standard browser actions cannot achieve the desired goal. "
     "This action takes a screenshot and uses OpenAI CUA to determine the next GUI action, "
@@ -436,7 +430,4 @@ if __name__ == "__main__":
     print("  - Custom UI elements that don't respond to standard actions")
     print()
 
-    asyncio.run(main())
-
-if __name__ == "__main__":
     asyncio.run(main())


### PR DESCRIPTION
## Summary

Fixes #180.

The browser-use-cua example had three sections copy-pasted twice: the imports block, the `tools = Tools()` instantiation, and the `if __name__ == "__main__"` entry point. The second `tools = Tools()` also overwrote the first binding, making any decorator attached between them silently dead code.

This PR collapses them to single occurrences each.

## Behavioral changes

- The example no longer runs `main()` twice on invocation (previously the two `__main__` blocks executed sequentially).
- No other functional change — the surviving `tools` binding is the one the rest of the file already uses.

## Test plan

- [x] Ran `python -m py_compile examples/browser-use-cua/main.py` — passes
- [x] Confirmed `tools = Tools()` appears once and all `@tools.registry.action(...)` decorators fall after it

## Related

Part of splitting closed PR #167. Previously opened: #171, #173, #175, #177, #179. This is the final bug (6 of 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)