### PR TITLE
feat(js-sdk): add describeSandbox method to retrieve sandbox info

### DIFF
--- a/sdk/js/src/providers/base.ts
+++ b/sdk/js/src/providers/base.ts
@@ -29,7 +29,9 @@ export abstract class BaseProvider {
    *
    * @param functionId - The function ID of the sandbox
    * @param sandboxId - The ID of the sandbox to retrieve
-   * @param kwargs - Additional parameters for sandbox retrieval
+   * @param kwargs - Additional parameters for sandbox retrieval.
+   * The first options object may include `includeDomains?: boolean`
+   * to control whether provider-specific domain data is enriched.
    * @returns The response containing sandbox details
    */
   abstract getSandbox(functionId: string, sandboxId: string, ...kwargs: any[]): Promise<any>;

--- a/sdk/js/src/providers/volcengine.ts
+++ b/sdk/js/src/providers/volcengine.ts
@@ -164,7 +164,9 @@ export class VolcengineProvider extends BaseProvider {
    *
    * @param functionId - The function ID of the sandbox
    * @param sandboxId - The ID of the sandbox to retrieve
-   * @param kwargs - Additional parameters for sandbox retrieval
+   * @param kwargs - Additional parameters for sandbox retrieval.
+   * Pass `{ includeDomains: false }` to skip APIG domain enrichment and
+   * return the raw DescribeSandbox response.
    * @returns The response containing sandbox details
    */
   async getSandbox(
@@ -173,10 +175,16 @@ export class VolcengineProvider extends BaseProvider {
     ...kwargs: any[]
   ): Promise<any> {
     try {
+      const params = kwargs[0] || {};
+      const {
+        includeDomains = true,
+        ...requestParams
+      } = params;
+
       const body = JSON.stringify({
         SandboxId: sandboxId,
         FunctionId: functionId,
-        ...kwargs[0]
+        ...requestParams
       });
 
       const response = await request(
@@ -191,7 +199,7 @@ export class VolcengineProvider extends BaseProvider {
         body,
       );
 
-      if (response?.Result) {
+      if (includeDomains && response?.Result) {
         const baseDomains = await this.getApigDomains(functionId);
         const domainsStruct = this.appendInstanceQueryStruct(
           baseDomains,


### PR DESCRIPTION
  ## Summary

  This PR adds an optional `includeDomains` flag to `getSandbox` in the JS SDK.
  By default, `getSandbox` keeps the current behavior and enriches the response with APIG domain information. Callers can now
  pass `{ includeDomains: false }` to skip domain enrichment and return the raw `DescribeSandbox` response.

  ## Motivation

  Some callers only need the sandbox details returned by `DescribeSandbox` and do not need the extra APIG domain lookup.
Adding this option keeps the behavior in a single API entry point instead of introducing a separate sandbox lookup method
  for the raw response case.

  ## Changes

  - add `includeDomains?: boolean` to the documented `getSandbox` options in `BaseProvider`
  - update `VolcengineProvider.getSandbox` to parse `includeDomains` from the first options object
  - exclude `includeDomains` from the upstream `DescribeSandbox` request payload
  - only enrich `response.Result.domains` when `includeDomains` is `true` 