### PR TITLE
ci: mirror multi-platform sandbox images to ghcr

### DIFF
--- a/.github/workflows/push-to-ghcr.yml
+++ b/.github/workflows/push-to-ghcr.yml
@@ -8,6 +8,10 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  SOURCE_REGISTRY: enterprise-public-cn-beijing.cr.volces.com
+  SOURCE_IMAGE_NAME: vefaas-public/all-in-one-sandbox
+  # Docker uses linux/arm64 for ARM64/aarch64 hosts.
+  PLATFORMS: linux/amd64,linux/arm64
 
 jobs:
   push-to-ghcr:
@@ -32,28 +36,61 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pull source image
-        id: pull
-        run: |
-          # For releases, use the version tag; otherwise use latest
-          if [[ "${{ github.event_name }}" == "release" ]]; then
-            # Remove 'v' prefix from tag name (e.g., v1.0.0.1 -> 1.0.0.1)
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
-            docker pull enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:${VERSION}
-            echo "source_tag=${VERSION}" >> "$GITHUB_OUTPUT"
-          else
-            docker pull enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
-            echo "source_tag=latest" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Mirror multi-arch image to GHCR
+      - name: Resolve source image
+        id: source
         shell: bash
         run: |
           set -euo pipefail
 
-          SOURCE_TAG="${{ steps.pull.outputs.source_tag }}"
-          SOURCE_IMAGE="enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:${SOURCE_TAG}"
+          # For releases, use the version tag; otherwise use latest.
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            SOURCE_TAG="${{ github.event.release.tag_name }}"
+            SOURCE_TAG="${SOURCE_TAG#v}"
+          else
+            SOURCE_TAG="latest"
+          fi
+
+          SOURCE_IMAGE="${{ env.SOURCE_REGISTRY }}/${{ env.SOURCE_IMAGE_NAME }}:${SOURCE_TAG}"
+          echo "source_tag=${SOURCE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "source_image=${SOURCE_IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify source image platforms
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SOURCE_IMAGE="${{ steps.source.outputs.source_image }}"
+          echo "Inspecting ${SOURCE_IMAGE}"
+          INSPECT_OUTPUT="$(docker buildx imagetools inspect "${SOURCE_IMAGE}")"
+          echo "${INSPECT_OUTPUT}"
+
+          IFS=',' read -ra REQUIRED_PLATFORMS <<< "${{ env.PLATFORMS }}"
+          for platform in "${REQUIRED_PLATFORMS[@]}"; do
+            platform="${platform//[[:space:]]/}"
+            if [[ -z "${platform}" ]]; then
+              continue
+            fi
+
+            os="${platform%%/*}"
+            arch="${platform#*/}"
+            arch="${arch%%/*}"
+
+            case "${INSPECT_OUTPUT}" in
+              *"Platform:    ${os}/${arch}"*) ;;
+              *)
+                echo "::error::Source image ${SOURCE_IMAGE} is missing ${platform}"
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Mirror multi-platform image to GHCR
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SOURCE_TAG="${{ steps.source.outputs.source_tag }}"
+          SOURCE_IMAGE="${{ steps.source.outputs.source_image }}"
           DEST_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
 
           TAG_ARGS=(-t "${DEST_IMAGE}:latest")
@@ -63,4 +100,6 @@ jobs:
             TAG_ARGS+=(-t "${DEST_IMAGE}:${VERSION}")
           fi
 
-          docker buildx imagetools create "${TAG_ARGS[@]}" "${SOURCE_IMAGE}"
+          docker buildx imagetools create \
+            "${TAG_ARGS[@]}" \
+            "${SOURCE_IMAGE}"

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ For users in mainland China:
 docker run --security-opt seccomp=unconfined --rm -it -p 8080:8080 enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 ```
 
+> The published images are multi-platform and support `linux/amd64` and `linux/arm64` (aarch64). Docker automatically pulls the matching image for your host architecture.
+
 Use a specific version in the format `agent-infra/sandbox:${version}`, for example, to use version 1.0.0.150:
 
 ```bash

--- a/website/docs/en/guide/start/quick-start.mdx
+++ b/website/docs/en/guide/start/quick-start.mdx
@@ -26,6 +26,8 @@ Use the public China mirror for faster downloads:
 docker run --security-opt seccomp=unconfined --rm -it -p 8080:8080 enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 ```
 
+> Published images support `linux/amd64` and `linux/arm64` (aarch64). Docker automatically selects the matching image for your host.
+
 ### Option 3: Use a specific version
 
 Format `agent-infra/sandbox:${version}`, for example, to use version 1.0.0.150:

--- a/website/docs/zh/guide/start/quick-start.mdx
+++ b/website/docs/zh/guide/start/quick-start.mdx
@@ -26,6 +26,8 @@ docker run --security-opt seccomp=unconfined --rm -it -p 8080:8080 ghcr.io/agent
 docker run --security-opt seccomp=unconfined --rm -it -p 8080:8080 enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 ```
 
+> 已发布镜像支持 `linux/amd64` 和 `linux/arm64`（aarch64）。Docker 会根据宿主机架构自动拉取匹配镜像。
+
 > 如果端口 8080 被占用，映射到不同的端口：
 
 ```bash


### PR DESCRIPTION
## Summary
- Mirror the upstream sandbox image as a multi-platform GHCR manifest list instead of pulling a single runner-architecture image first.
- Add explicit source-image platform verification for `linux/amd64` and `linux/arm64` before publishing.
- Document Docker image support for `linux/amd64` and `linux/arm64` (aarch64) in README and quick-start docs.

## Why
The current workflow pulls the source image before mirroring. On `ubuntu-latest`, that can resolve to only the runner architecture (`linux/amd64`), so the GHCR mirror may lose `linux/arm64` support. This PR mirrors the upstream manifest list directly with `docker buildx imagetools create` and fails early if a required platform is missing.

## Test Plan
- [x] Static workflow assertions for multi-platform settings
- [x] Source registry manifest check includes `linux/amd64` and `linux/arm64`
- [x] YAML parse check for workflow and `docker-compose.yaml`
- [x] `npx prettier --check .github/workflows/push-to-ghcr.yml`
- [x] Docs platform note assertions
- [x] `git diff --check`

Note: Markdown/MDX full Prettier check already failed on baseline files, so this PR avoids unrelated formatting churn.
