### PR TITLE
fix(docs): correct browser CDP API usage in documentation

### DIFF
--- a/website/docs/en/blog/announcing-0.mdx
+++ b/website/docs/en/blog/announcing-0.mdx
@@ -475,7 +475,7 @@ screenshot = client.browser.screenshot()
 print(screenshot)
 
 # Get Browser CDP
-browser_info = client.browser.get_browser_info()
+browser_info = client.browser.get_info()
 cdp_url = browser_info.data.cdp_url # ws://
 
 # Read File
@@ -536,7 +536,7 @@ tools = [{
 }]
 
 async def link_reader(url: str, timeout_ms: int = 30_000) -> dict:
-    cdp_url = sandbox.browser.get_browser_info().cdp_url
+    cdp_url = sandbox.browser.get_info().data.cdp_url
     async with async_playwright() as p:
         browser = await p.chromium.connect_over_cdp(cdp_url)
         try:

--- a/website/docs/en/guide/advanced/browser-downloads.md
+++ b/website/docs/en/guide/advanced/browser-downloads.md
@@ -27,7 +27,7 @@ from agent_sandbox import Sandbox
 from playwright.sync_api import sync_playwright
 
 client = Sandbox(base_url="http://localhost:8080")
-cdp_url = client.browser.get_info().cdp_url
+cdp_url = client.browser.get_info().data.cdp_url
 
 with sync_playwright() as p:
     browser = p.chromium.connect_over_cdp(cdp_url)

--- a/website/docs/en/guide/basic/browser.mdx
+++ b/website/docs/en/guide/basic/browser.mdx
@@ -71,11 +71,11 @@ client = Sandbox(base_url="http://localhost:8080")
 
 # Get browser information
 browser_info = client.browser.get_info()
-print(f"CDP URL: {browser_info.cdp_url}")
-print(f"Viewport: {browser_info.viewport}")
+print(f"CDP URL: {browser_info.data.cdp_url}")
+print(f"Viewport: {browser_info.data.viewport}")
 
 # Take screenshot
-screenshot_data = client.browser.take_screenshot()
+screenshot_data = client.browser.screenshot()
 with open("screenshot.png", "wb") as f:
     for chunk in screenshot_data:
         f.write(chunk)
@@ -111,10 +111,10 @@ async def main():
 
     # Get browser information
     browser_info = await client.browser.get_info()
-    print(f"CDP URL: {browser_info.cdp_url}")
+    print(f"CDP URL: {browser_info.data.cdp_url}")
 
     # Take screenshot
-    screenshot_data = client.browser.take_screenshot()
+    screenshot_data = client.browser.screenshot()
     with open("screenshot.png", "wb") as f:
         async for chunk in screenshot_data:
             f.write(chunk)
@@ -145,7 +145,7 @@ from browser_use.browser.browser import BrowserSession, BrowserProfile
 
 # Get CDP URL
 client = Sandbox(base_url="http://localhost:8080")
-cdp_url = client.browser.get_info().cdp_url
+cdp_url = client.browser.get_info().data.cdp_url
 
 # Configure browser profile
 profile = {
@@ -177,7 +177,7 @@ client = Sandbox(base_url="http://localhost:8080")
 
 async with async_playwright() as p:
     browser_info = client.browser.get_info()
-    cdp_url = browser_info.cdp_url
+    cdp_url = browser_info.data.cdp_url
 
     browser = await p.chromium.connect_over_cdp(cdp_url)
     page = await browser.new_page()

--- a/website/docs/zh/blog/announcing-0.mdx
+++ b/website/docs/zh/blog/announcing-0.mdx
@@ -470,7 +470,7 @@ screenshot = client.browser.screenshot()
 print(screenshot)
 
 # Get Browser CDP
-browser_info = client.browser.get_browser_info()
+browser_info = client.browser.get_info()
 cdp_url = browser_info.data.cdp_url # ws://
 
 # Read File
@@ -531,7 +531,7 @@ tools = [{
 }]
 
 async def link_reader(url: str, timeout_ms: int = 30_000) -> dict:
-    cdp_url = sandbox.browser.get_browser_info().cdp_url
+    cdp_url = sandbox.browser.get_info().data.cdp_url
     async with async_playwright() as p:
         browser = await p.chromium.connect_over_cdp(cdp_url)
         try:

--- a/website/docs/zh/guide/advanced/browser-downloads.md
+++ b/website/docs/zh/guide/advanced/browser-downloads.md
@@ -27,7 +27,7 @@ from agent_sandbox import Sandbox
 from playwright.sync_api import sync_playwright
 
 client = Sandbox(base_url="http://localhost:8080")
-cdp_url = client.browser.get_info().cdp_url
+cdp_url = client.browser.get_info().data.cdp_url
 
 with sync_playwright() as p:
     browser = p.chromium.connect_over_cdp(cdp_url)

--- a/website/docs/zh/guide/basic/browser.mdx
+++ b/website/docs/zh/guide/basic/browser.mdx
@@ -71,11 +71,11 @@ client = Sandbox(base_url="http://localhost:8080")
 
 # 获取浏览器信息
 browser_info = client.browser.get_info()
-print(f"CDP URL: {browser_info.cdp_url}")
-print(f"Viewport: {browser_info.viewport}")
+print(f"CDP URL: {browser_info.data.cdp_url}")
+print(f"Viewport: {browser_info.data.viewport}")
 
 # 截图
-screenshot_data = client.browser.take_screenshot()
+screenshot_data = client.browser.screenshot()
 with open("screenshot.png", "wb") as f:
     for chunk in screenshot_data:
         f.write(chunk)
@@ -111,10 +111,10 @@ async def main():
 
     # 获取浏览器信息
     browser_info = await client.browser.get_info()
-    print(f"CDP URL: {browser_info.cdp_url}")
+    print(f"CDP URL: {browser_info.data.cdp_url}")
 
     # 截图
-    screenshot_data = client.browser.take_screenshot()
+    screenshot_data = client.browser.screenshot()
     with open("screenshot.png", "wb") as f:
         async for chunk in screenshot_data:
             f.write(chunk)
@@ -145,7 +145,7 @@ from browser_use.browser.browser import BrowserSession, BrowserProfile
 
 # 获取 CDP URL
 client = Sandbox(base_url="http://localhost:8080")
-cdp_url = client.browser.get_info().cdp_url
+cdp_url = client.browser.get_info().data.cdp_url
 
 # 配置浏览器配置文件
 profile = {
@@ -177,7 +177,7 @@ client = Sandbox(base_url="http://localhost:8080")
 
 async with async_playwright() as p:
     browser_info = client.browser.get_info()
-    cdp_url = browser_info.cdp_url
+    cdp_url = browser_info.data.cdp_url
 
     browser = await p.chromium.connect_over_cdp(cdp_url)
     page = await browser.new_page()


### PR DESCRIPTION
fix some outdated document 

- `get_browser_info()` -> `get_info()`
- `browser_info.cdp_url` -> `browser_info.data.cdp_url`
- `take_screenshot()` -> `screenshot()`
