### PR TITLE
docs: add sandbox API key example

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@
 Get up and running in 30 seconds:
 
 ```bash
+# Recommended: Enable API Key authentication (protects all services: API, JupyterLab, VNC)
+# - Supports three methods: X-AIO-API-Key header, Authorization: Bearer header, ?api_key= query parameter
+# - Without SANDBOX_API_KEY, services remain open (backward compatible)
 docker run --security-opt seccomp=unconfined --rm -it \
+  -e SANDBOX_API_KEY=your-secret-key \
   -p 127.0.0.1:8080:8080 ghcr.io/agent-infra/sandbox:latest
 ```
 
@@ -40,6 +44,7 @@ For users in mainland China:
 
 ```bash
 docker run --security-opt seccomp=unconfined --rm -it \
+  -e SANDBOX_API_KEY=your-secret-key \
   -p 127.0.0.1:8080:8080 enterprise-public-cn-beijing.cr.volces.com/vefaas-public/all-in-one-sandbox:latest
 ```
 

--- a/examples/_template/README.md
+++ b/examples/_template/README.md
@@ -7,7 +7,11 @@ Brief description of what this example demonstrates.
 1. Start the sandbox
 
 ```bash
+# Recommended: Enable API Key authentication (protects all services: API, JupyterLab, VNC)
+# - Supports three methods: X-AIO-API-Key header, Authorization: Bearer header, ?api_key= query parameter
+# - Without SANDBOX_API_KEY, services remain open (backward compatible)
 docker run --security-opt seccomp=unconfined --rm -it \
+  -e SANDBOX_API_KEY=your-secret-key \
   -p 127.0.0.1:8080:8080 ghcr.io/agent-infra/sandbox:latest
 ```
 


### PR DESCRIPTION
## 背景

#215 已经补回了本地回环地址绑定和云上部署安全提示。这次继续补回旧 PR #158 中关于 `SANDBOX_API_KEY` 的启动示例，让用户能在文档入口直接看到如何开启镜像内置的 API Key 鉴权。

## 变更内容

- 在根 `README.md` 的快速启动示例中加入 `-e SANDBOX_API_KEY=your-secret-key`。
- 在中国大陆镜像的快速启动示例中加入同样的环境变量。
- 在 `examples/_template/README.md` 中同步补充 API Key 启动示例。
- 保留旧 PR #158 中说明的三种请求方式：`X-AIO-API-Key` header、`Authorization: Bearer` header、`?api_key=` query parameter。

## 验证

- `rg -n -- "SANDBOX_API_KEY|X-AIO-API-Key|your-secret-key|api_key" README.md examples/_template/README.md`
- `git diff --check origin/main...HEAD`