### PR TITLE
fix(sdk): use & separator when baseUrl already contains query params

### DIFF
--- a/sdk/js/__test__/core/createRequestUrl.test.ts
+++ b/sdk/js/__test__/core/createRequestUrl.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { createRequestUrl } from '../../src/core/fetcher/createRequestUrl.js';
+
+describe('createRequestUrl', () => {
+  it('should return baseUrl unchanged when no query parameters', () => {
+    expect(createRequestUrl('https://api.example.com/v1')).toBe('https://api.example.com/v1');
+  });
+
+  it('should append query string with ? when baseUrl has no query params', () => {
+    const result = createRequestUrl('https://api.example.com/v1', { key: 'value' });
+    expect(result).toBe('https://api.example.com/v1?key=value');
+  });
+
+  it('should append query string with & when baseUrl already has query params', () => {
+    const result = createRequestUrl('https://api.example.com/v1?token=abc', { key: 'value' });
+    expect(result).toBe('https://api.example.com/v1?token=abc&key=value');
+  });
+
+  it('should handle empty query parameters', () => {
+    const result = createRequestUrl('https://api.example.com/v1?token=abc', {});
+    expect(result).toBe('https://api.example.com/v1?token=abc');
+  });
+});

--- a/sdk/js/src/core/fetcher/createRequestUrl.ts
+++ b/sdk/js/src/core/fetcher/createRequestUrl.ts
@@ -2,5 +2,9 @@ import { toQueryString } from "../url/qs.js";
 
 export function createRequestUrl(baseUrl: string, queryParameters?: Record<string, unknown>): string {
     const queryString = toQueryString(queryParameters, { arrayFormat: "repeat" });
-    return queryString ? `${baseUrl}?${queryString}` : baseUrl;
+    if (!queryString) {
+        return baseUrl;
+    }
+    const separator = baseUrl.includes("?") ? "&" : "?";
+    return `${baseUrl}${separator}${queryString}`;
 }


### PR DESCRIPTION
This PR addresses: fix(sdk): use & separator when baseUrl already contains query params