### PR TITLE
docs: fix edit-page source links

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -113,7 +113,7 @@ export default defineConfig({
         label: 'English',
         editLink: {
           docRepoBaseUrl:
-            'https://github.com/agent-infra/sandbox/tree/main/site/docs',
+            'https://github.com/agent-infra/sandbox/tree/main/website/docs',
           text: '📝 Edit this page on GitHub',
         },
         searchPlaceholderText: 'Search',
@@ -126,7 +126,7 @@ export default defineConfig({
         label: '简体中文',
         editLink: {
           docRepoBaseUrl:
-            'https://github.com/agent-infra/sandbox/tree/main/site/docs',
+            'https://github.com/agent-infra/sandbox/tree/main/website/docs',
           text: '📝 在 GitHub 上编辑此页',
         },
         searchPlaceholderText: '搜索',


### PR DESCRIPTION
## Summary
- point English and Chinese Rspress edit links at the tracked `website/docs` source
- restore working GitHub edit navigation across both locales

## Verification
- `pnpm --filter website build`
- inspected the generated English and Chinese introduction pages and confirmed `website/docs` URLs with no remaining `site/docs` edit links

Closes #234