### PR TITLE
fix(examples): use async sandbox in browser-use CUA

### DIFF
--- a/examples/browser-use-cua/main.py
+++ b/examples/browser-use-cua/main.py
@@ -12,7 +12,7 @@ import base64
 import os
 from io import BytesIO
 
-from agent_sandbox import Sandbox
+from agent_sandbox import AsyncSandbox
 from agent_sandbox.browser.types.action import (
     Action_Click,
     Action_DoubleClick,
@@ -33,12 +33,7 @@ if TYPE_CHECKING:
 load_dotenv()
 
 sandbox_url = os.getenv("SANDBOX_BASE_URL", "http://localhost:8080")
-sandbox = Sandbox(base_url=sandbox_url)
-cdp_url = sandbox.browser.get_info().data.cdp_url
-
-browser_session = BrowserSession(
-    browser_profile=BrowserProfile(cdp_url=cdp_url, is_local=True)
-)
+sandbox = AsyncSandbox(base_url=sandbox_url)
 tools = Tools()
 
 
@@ -80,15 +75,12 @@ async def handle_cua_action(action: "ComputerAction") -> ActionResult:
 
                 print(f"Action: click at ({x}, {y}) with button '{button}'")
 
-                # Map CUA button to sandbox button
-                from agent_sandbox.browser.types.action import Button
-
                 button_map = {
-                    "left": Button.LEFT,
-                    "right": Button.RIGHT,
-                    "middle": Button.MIDDLE,
+                    "left": "left",
+                    "right": "right",
+                    "middle": "middle",
                 }
-                sandbox_button = button_map.get(button, Button.LEFT)
+                sandbox_button = button_map.get(button, "left")
 
                 await sandbox.browser.execute_action(
                     request=Action_Click(
@@ -388,7 +380,13 @@ async def sandbox_gui_fallback(
 
 
 async def main():
-    browser_session = BrowserSession(browser_profile=BrowserProfile(cdp_url=cdp_url))
+    browser_info = await sandbox.browser.get_info()
+    browser_session = BrowserSession(
+        browser_profile=BrowserProfile(
+            cdp_url=browser_info.data.cdp_url,
+            is_local=True,
+        )
+    )
 
     # Task that might require GUI fallback for complex interactions
     task = """


### PR DESCRIPTION
## Summary
- use AsyncSandbox for the awaited browser calls in the official Browser Use CUA example
- resolve CDP inside async main while keeping is_local=True
- pass the generated left/right/middle button strings directly

## Why
Browser Use is the agent in this example. The runtime failures are in the adapter: it awaits and async-iterates methods from the synchronous Sandbox client, and it treats the generated Button string type as an enum with LEFT, RIGHT, and MIDDLE members.

No Browser Use core code changes.

## Checks
- Python 3.12 compile
- generated SDK probe: get_info and execute_action are coroutines; screenshot is an async generator
- mocked flow: screenshot bytes, one left click, CDP setup, Browser Use agent run, and cleanup
- Ruff diagnostics match current main; git diff --check passes
- exact one-file secret scan: zero findings

PR #181 remains separate duplicate-import, duplicate-Tools, and duplicate-main cleanup.